### PR TITLE
🏗️ build(pyproject): re-generate `pyproject.toml`

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -632,5 +632,5 @@ files = [
 
 [metadata]
 lock-version = "2.1"
-python-versions = "^3.11"
-content-hash = "1ef4fba394fe476ac85cb183a1d183a904aafeff5b85a525de9362c27530da3e"
+python-versions = ">=3.11"
+content-hash = "a07f526e2917ce84b34ae47ab64df3a2323456a87d9f78893376befbe71f81b0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,17 +1,22 @@
-[tool.poetry]
+[project]
 name = "dmd"
 version = "0.0.1"
 description = ""
-authors = ["mukappalambda <maokailan24@gmail.com>"]
+authors = [
+    {name = "mukappalambda",email = "maokailan24@gmail.com"}
+]
 readme = "README.md"
+requires-python = ">=3.11"
+dependencies = [
+    "numpy (>=1.25)",
+    "pandas (>=2.0)",
+    "matplotlib (>=3.8.0)"
+]
 
-[tool.poetry.dependencies]
-python = "^3.11"
-numpy = ">=1.25"
-pandas = ">=2.0"
-matplotlib = ">=3.8.0"
+[tool.poetry]
 
+[tool.poetry.group.dev.dependencies]
 
 [build-system]
-requires = ["poetry-core"]
+requires = ["poetry-core>=2.0.0,<3.0.0"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
The reason for doing this is that a number of warnings are shown when executing the `poetry check` command.

Previously, we had these warnings:

```console
$ poetry check
Warning: [tool.poetry.name] is deprecated. Use [project.name] instead.
Warning: [tool.poetry.version] is set but 'version' is not in [project.dynamic]. If it is static use [project.version]. If it is dynamic, add 'version' to [project.dynamic].
If you want to set the version dynamically via `poetry build --local-version` or you are using a plugin, which sets the version dynamically, you should define the version in [tool.poetry] and add 'version' to [project.dynamic].
Warning: [tool.poetry.description] is deprecated. Use [project.description] instead.
Warning: [tool.poetry.readme] is set but 'readme' is not in [project.dynamic]. If it is static use [project.readme]. If it is dynamic, add 'readme' to [project.dynamic].
If you want to define multiple readmes, you should define them in [tool.poetry] and add 'readme' to [project.dynamic].
Warning: [tool.poetry.authors] is deprecated. Use [project.authors] instead.
```

After this commit, those warnings are addressed, hence this PR.